### PR TITLE
Get continent for jobs

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,3 +1,3 @@
 [
-  inputs: ["*.exs", "src/*.{ex}"]
+  inputs: ["*.exs", "lib/*.{ex}"]
 ]

--- a/lib/geo.ex
+++ b/lib/geo.ex
@@ -1,7 +1,15 @@
 defmodule Geo do
+  # Circle shapes drawn using https://www.calcmaps.com/map-radius/
+
+  @type latitude :: float()
+  @type longitude :: float()
   @type continent :: :europe | :northamerica | :africa | :australia | :asia | :other
 
-  # Draw using https://www.calcmaps.com/map-radius/
+  @spec isCoordinatesInArea?(latitude, longitude, Geocalc.Shape.Circle.t()) :: boolean
+  defp isCoordinatesInArea?(lat, lon, area) do
+    point = %{lat: lat, lng: lon}
+    Geocalc.in_area?(area, point)
+  end
 
   # Europe
   # Radius: 2181215 m | 2181.21 km | 1355.34 mi | 7156217 ft | 1177.76 nm
@@ -12,7 +20,6 @@ defmodule Geo do
   # Radius: 591047 m | 591.05 km | 367.26 mi | 1939130 ft | 319.14 nm
   # Circle Area: 1097472125815 m2 | 1097472.13 km2
   # Lat,Lon: 41.17816,-4.24584
-
   defp isInEurope(latitude, longitude) do
     europe = %Geocalc.Shape.Circle{
       latitude: 56.54461,
@@ -26,19 +33,14 @@ defmodule Geo do
       radius: 591_047
     }
 
-    point = %{lat: latitude, lng: longitude}
-    Geocalc.in_area?(europe, point) || Geocalc.in_area?(spainAndPortugal, point)
+    isCoordinatesInArea?(latitude, longitude, europe) ||
+      isCoordinatesInArea?(latitude, longitude, spainAndPortugal)
   end
 
   # North America
-  # Radius: 4128146 m | 4128.15 km | 2565.11 mi | 13543788 ft | 2229.02 nm
-  # Circle Area: 53537740280051 m2 | 53537740.28 km2
-  # Lat,Lon: 48.69096,-102.30479
-
   # Radius: 4339075 m | 4339.07 km | 2696.18 mi | 14235809 ft | 2342.91 nm
   # Circle Area: 59148550160090 m2 | 59148550.16 km2
   # Lat,Lon: 43.58039,-108.28788
-
   defp isInNorthAmerica(latitude, longitude) do
     northAmerica = %Geocalc.Shape.Circle{
       latitude: 43.58039,
@@ -46,8 +48,7 @@ defmodule Geo do
       radius: 4_339_075
     }
 
-    point = %{lat: latitude, lng: longitude}
-    Geocalc.in_area?(northAmerica, point)
+    isCoordinatesInArea?(latitude, longitude, northAmerica)
   end
 
   # Africa
@@ -62,15 +63,13 @@ defmodule Geo do
       radius: 4_288_616
     }
 
-    point = %{lat: latitude, lng: longitude}
-    Geocalc.in_area?(africa, point)
+    isCoordinatesInArea?(latitude, longitude, africa)
   end
 
   # Asia
   # Radius: 5255297 m | 5255.30 km | 3265.49 mi | 17241790 ft | 2837.63 nm
   # Circle Area: 86764979261076 m2 | 86764979.26 km2
   # Lat,Lon: 34.30714,96.69073
-
   defp isInAsia(latitude, longitude) do
     asia = %Geocalc.Shape.Circle{
       latitude: 34.30714,
@@ -78,15 +77,13 @@ defmodule Geo do
       radius: 5_255_297
     }
 
-    point = %{lat: latitude, lng: longitude}
-    Geocalc.in_area?(asia, point)
+    isCoordinatesInArea?(latitude, longitude, asia)
   end
 
   # Australia
   # Radius: 3230549 m | 3230.55 km | 2007.37 mi | 10598913 ft | 1744.36 nm
   # Circle Area: 32787058546523 m2 | 32787058.55 km2
   # Lat,Lon: -25.89887,146.40949
-
   defp isInAustralia(latitude, longitude) do
     australia = %Geocalc.Shape.Circle{
       latitude: -25.89887,
@@ -94,8 +91,7 @@ defmodule Geo do
       radius: 3_230_549
     }
 
-    point = %{lat: latitude, lng: longitude}
-    Geocalc.in_area?(australia, point)
+    isCoordinatesInArea?(latitude, longitude, australia)
   end
 
   @doc ~S"""
@@ -141,7 +137,7 @@ defmodule Geo do
       :other
 
   """
-  @spec getContinent(float(), float()) :: continent
+  @spec getContinent(latitude(), longitude()) :: continent
   def getContinent(latitude, longitude) do
     cond do
       isInEurope(latitude, longitude) -> :europe

--- a/lib/geo.ex
+++ b/lib/geo.ex
@@ -1,0 +1,155 @@
+defmodule Geo do
+  @type continent :: :europe | :northamerica | :africa | :australia | :asia | :other
+
+  # Draw using https://www.calcmaps.com/map-radius/
+
+  # Europe
+  # Radius: 2181215 m | 2181.21 km | 1355.34 mi | 7156217 ft | 1177.76 nm
+  # Circle Area: 14946750746399 m2 | 14946750.75 km2
+  # Lat,Lon: 56.54461,10.91914
+
+  # Spain and Portugal
+  # Radius: 591047 m | 591.05 km | 367.26 mi | 1939130 ft | 319.14 nm
+  # Circle Area: 1097472125815 m2 | 1097472.13 km2
+  # Lat,Lon: 41.17816,-4.24584
+
+  def isInEurope(latitude, longitude) do
+    europe = %Geocalc.Shape.Circle{
+      latitude: 56.54461,
+      longitude: 10.91914,
+      radius: 2_181_215
+    }
+
+    spainAndPortugal = %Geocalc.Shape.Circle{
+      latitude: 41.17816,
+      longitude: -4.24584,
+      radius: 591_047
+    }
+
+    point = %{lat: latitude, lng: longitude}
+    Geocalc.in_area?(europe, point) || Geocalc.in_area?(spainAndPortugal, point)
+  end
+
+  # North America
+  # Radius: 4128146 m | 4128.15 km | 2565.11 mi | 13543788 ft | 2229.02 nm
+  # Circle Area: 53537740280051 m2 | 53537740.28 km2
+  # Lat,Lon: 48.69096,-102.30479
+
+  # Radius: 4339075 m | 4339.07 km | 2696.18 mi | 14235809 ft | 2342.91 nm
+  # Circle Area: 59148550160090 m2 | 59148550.16 km2
+  # Lat,Lon: 43.58039,-108.28788
+
+  def isInNorthAmerica(latitude, longitude) do
+    northAmerica = %Geocalc.Shape.Circle{
+      latitude: 43.58039,
+      longitude: -108.28788,
+      radius: 4_339_075
+    }
+
+    point = %{lat: latitude, lng: longitude}
+    Geocalc.in_area?(northAmerica, point)
+  end
+
+  # Africa
+  # Radius: 4288616 m | 4288.62 km | 2664.82 mi | 14070261 ft | 2315.67 nm
+  # Circle Area: 57780874169219 m2 | 57780874.17 km2
+  # Lat,Lon: -0.35156,9.14677
+
+  def isInAfrica(latitude, longitude) do
+    africa = %Geocalc.Shape.Circle{
+      latitude: -0.35156,
+      longitude: 9.14677,
+      radius: 4_288_616
+    }
+
+    point = %{lat: latitude, lng: longitude}
+    Geocalc.in_area?(africa, point)
+  end
+
+  # Asia
+  # Radius: 5255297 m | 5255.30 km | 3265.49 mi | 17241790 ft | 2837.63 nm
+  # Circle Area: 86764979261076 m2 | 86764979.26 km2
+  # Lat,Lon: 34.30714,96.69073
+
+  def isInAsia(latitude, longitude) do
+    asia = %Geocalc.Shape.Circle{
+      latitude: 34.30714,
+      longitude: 96.69073,
+      radius: 5_255_297
+    }
+
+    point = %{lat: latitude, lng: longitude}
+    Geocalc.in_area?(asia, point)
+  end
+
+  # Australia
+  # Radius: 3230549 m | 3230.55 km | 2007.37 mi | 10598913 ft | 1744.36 nm
+  # Circle Area: 32787058546523 m2 | 32787058.55 km2
+  # Lat,Lon: -25.89887,146.40949
+
+  def isInAustralia(latitude, longitude) do
+    australia = %Geocalc.Shape.Circle{
+      latitude: -25.89887,
+      longitude: 146.40949,
+      radius: 3_230_549
+    }
+
+    point = %{lat: latitude, lng: longitude}
+    Geocalc.in_area?(australia, point)
+  end
+
+  @doc ~S"""
+
+    Return the continent associated to the given job
+
+    ## Examples
+
+      # Melbourne
+      iex> Geo.getContinent(-37.814479, 144.965794)
+      :australia
+
+      # Paris
+      iex> Geo.getContinent(48.8588897, 2.320041)
+      :europe
+
+      # Lisbonne
+      iex> Geo.getContinent(38.6979940, -9.1265504)
+      :europe
+
+      # Moscou
+      iex> Geo.getContinent(55.7504461, 37.6174943)
+      :europe
+
+      # Moscou
+      iex> Geo.getContinent(55.7504461, 37.6174943)
+      :europe
+
+      # Pekin
+      iex> Geo.getContinent(39.8919532, 116.4442401)
+      :asia
+
+      # Le Caire
+      iex> Geo.getContinent(30.0443879, 31.2357257)
+      :africa
+
+      # New York
+      iex> Geo.getContinent(40.7127281, -74.0060152)
+      :northamerica
+
+      # Other (pacific ocean)
+      iex> Geo.getContinent(42.7341014, -175.879978)
+      :other
+
+  """
+  @spec getContinent(float(), float()) :: continent
+  def getContinent(latitude, longitude) do
+    cond do
+      isInEurope(latitude, longitude) -> :europe
+      isInNorthAmerica(latitude, longitude) -> :northamerica
+      isInAfrica(latitude, longitude) -> :africa
+      isInAsia(latitude, longitude) -> :asia
+      isInAustralia(latitude, longitude) -> :australia
+      true -> :other
+    end
+  end
+end

--- a/lib/geo.ex
+++ b/lib/geo.ex
@@ -13,7 +13,7 @@ defmodule Geo do
   # Circle Area: 1097472125815 m2 | 1097472.13 km2
   # Lat,Lon: 41.17816,-4.24584
 
-  def isInEurope(latitude, longitude) do
+  defp isInEurope(latitude, longitude) do
     europe = %Geocalc.Shape.Circle{
       latitude: 56.54461,
       longitude: 10.91914,
@@ -39,7 +39,7 @@ defmodule Geo do
   # Circle Area: 59148550160090 m2 | 59148550.16 km2
   # Lat,Lon: 43.58039,-108.28788
 
-  def isInNorthAmerica(latitude, longitude) do
+  defp isInNorthAmerica(latitude, longitude) do
     northAmerica = %Geocalc.Shape.Circle{
       latitude: 43.58039,
       longitude: -108.28788,
@@ -55,7 +55,7 @@ defmodule Geo do
   # Circle Area: 57780874169219 m2 | 57780874.17 km2
   # Lat,Lon: -0.35156,9.14677
 
-  def isInAfrica(latitude, longitude) do
+  defp isInAfrica(latitude, longitude) do
     africa = %Geocalc.Shape.Circle{
       latitude: -0.35156,
       longitude: 9.14677,
@@ -71,7 +71,7 @@ defmodule Geo do
   # Circle Area: 86764979261076 m2 | 86764979.26 km2
   # Lat,Lon: 34.30714,96.69073
 
-  def isInAsia(latitude, longitude) do
+  defp isInAsia(latitude, longitude) do
     asia = %Geocalc.Shape.Circle{
       latitude: 34.30714,
       longitude: 96.69073,
@@ -87,7 +87,7 @@ defmodule Geo do
   # Circle Area: 32787058546523 m2 | 32787058.55 km2
   # Lat,Lon: -25.89887,146.40949
 
-  def isInAustralia(latitude, longitude) do
+  defp isInAustralia(latitude, longitude) do
     australia = %Geocalc.Shape.Circle{
       latitude: -25.89887,
       longitude: 146.40949,

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -4,7 +4,8 @@ defmodule CSVParser do
           contractType: String.t(),
           name: String.t(),
           latitude: float(),
-          longitude:      float()
+          longitude: float(),
+          continent: Geo.continent()
         }
   @type jobs :: [job]
   @type profession :: %{id: integer(), name: String.t(), category: String.t()}
@@ -36,7 +37,7 @@ defmodule CSVParser do
     # Reject all the rows containing a blank value
     # Not sure if it's a good idea, but that was necessary to properly
     # convert the value in integer or float
-    |> Stream.reject(&(isAnyKeyBlank(&1)))
+    |> Stream.reject(&isAnyKeyBlank(&1))
     |> Stream.map(&func.(&1))
     |> Enum.to_list()
   end
@@ -54,15 +55,19 @@ defmodule CSVParser do
         "profession_id" => id,
         "contract_type" => contractType,
         "name" => name,
-        "office_latitude" => latitude,
-        "office_longitude" => longitude
+        "office_latitude" => latitudeStr,
+        "office_longitude" => longitudeStr
       } ->
+        lat = String.to_float(latitudeStr)
+        lon = String.to_float(longitudeStr)
+
         %{
           professionId: String.to_integer(id),
           contractType: contractType,
           name: name,
-          latitude: String.to_float(latitude),
-          longitude: String.to_float(longitude)
+          latitude: lat,
+          longitude: lon,
+          continent: Geo.getContinent(lat, lon)
         }
     end
   end
@@ -106,14 +111,16 @@ defmodule CSVParser do
         latitude: 48.1392154,
         longitude: 11.5781413,
         name: "[Louis Vuitton Germany] Praktikant (m/w) im Bereich Digital Retail (E-Commerce)",
-        professionId: 7
+        professionId: 7,
+        continent: :europe
       },
       %{
         contractType: "INTERNSHIP",
         latitude: 48.885247,
         longitude: 2.3566441,
         name: "Bras droit de la fondatrice",
-        professionId: 5
+        professionId: 5,
+        continent: :europe
       }]
   """
   @spec parseJobs() :: [job]

--- a/mix.exs
+++ b/mix.exs
@@ -24,6 +24,7 @@ defmodule TestElixir.MixProject do
   defp deps do
     [
       {:csv, "3.0.5"},
+      {:geocalc, "0.8.5"},
       {:dialyxir, "1.3.0", only: [:dev, :test], runtime: false}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
 %{
   "csv": {:hex, :csv, "3.0.5", "3c1455127e92de8845806db89554ad7d45e0212974be41dd9c38a5c881861713", [:mix], [], "hexpm", "cbbe5455c93df5f3f2943e995e28b7a8808361ba34cf3e44267d77a01eaf1609"},
+  "decimal": {:hex, :decimal, "2.1.1", "5611dca5d4b2c3dd497dec8f68751f1f1a54755e8ed2a966c2633cf885973ad6", [:mix], [], "hexpm", "53cfe5f497ed0e7771ae1a475575603d77425099ba5faef9394932b35020ffcc"},
   "dialyxir": {:hex, :dialyxir, "1.3.0", "fd1672f0922b7648ff9ce7b1b26fcf0ef56dda964a459892ad15f6b4410b5284", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "00b2a4bcd6aa8db9dcb0b38c1225b7277dca9bc370b6438715667071a304696f"},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
+  "geocalc": {:hex, :geocalc, "0.8.5", "b9886679e44c323e5b72dcd90a64f834d775d2600af0b656ea9f07ccdacaa5a6", [:mix], [{:decimal, "~> 2.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm", "3870c25c78513ec0456b69324c2be1af2202961002e81fb659559e3db162c802"},
 }

--- a/test/geo_test.exs
+++ b/test/geo_test.exs
@@ -1,0 +1,4 @@
+defmodule GeoTest do
+  use ExUnit.Case, async: true
+  doctest Geo
+end


### PR DESCRIPTION
To know if a job is part of a contient, I've used https://github.com/yltsrc/geocalc. 

Each continent is represented by [a circle shape](https://github.com/yltsrc/geocalc#check-if-a-point-is-inside-an-area). Using geocalc, I can easily know if a job (the latitude and the longitude) is inside a shape/continent.

Not sure if it's the best solution, since a circle shape represents a continent in a vague way. Indeed, the borders are not strict (I.E. continents contain areas of water).

I didn't want to use an API to retrieve the continent from coordinates, since it would imply a lot of calls (we already have ~5000 jobs in the csv). 

Maybe another library (other than geocalc) would be better to determine the continent.