### PR TITLE
Refactoring models services

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,3 +1,3 @@
 [
-  inputs: ["*.exs", "lib/*.{ex}"]
+  inputs: ["*.exs", "lib/*.ex", "test/*.exs"]
 ]

--- a/lib/continents.ex
+++ b/lib/continents.ex
@@ -1,4 +1,4 @@
-defmodule Geo do
+defmodule Continents do
   # Circle shapes drawn using https://www.calcmaps.com/map-radius/
 
   @type latitude :: float()
@@ -20,78 +20,73 @@ defmodule Geo do
   # Radius: 591047 m | 591.05 km | 367.26 mi | 1939130 ft | 319.14 nm
   # Circle Area: 1097472125815 m2 | 1097472.13 km2
   # Lat,Lon: 41.17816,-4.24584
+  @europe %Geocalc.Shape.Circle{
+    latitude: 56.54461,
+    longitude: 10.91914,
+    radius: 2_181_215
+  }
+
+  @spainAndPortugal %Geocalc.Shape.Circle{
+    latitude: 41.17816,
+    longitude: -4.24584,
+    radius: 591_047
+  }
+
   defp isInEurope(latitude, longitude) do
-    europe = %Geocalc.Shape.Circle{
-      latitude: 56.54461,
-      longitude: 10.91914,
-      radius: 2_181_215
-    }
-
-    spainAndPortugal = %Geocalc.Shape.Circle{
-      latitude: 41.17816,
-      longitude: -4.24584,
-      radius: 591_047
-    }
-
-    isCoordinatesInArea?(latitude, longitude, europe) ||
-      isCoordinatesInArea?(latitude, longitude, spainAndPortugal)
+    isCoordinatesInArea?(latitude, longitude, @europe) ||
+      isCoordinatesInArea?(latitude, longitude, @spainAndPortugal)
   end
 
   # North America
   # Radius: 4339075 m | 4339.07 km | 2696.18 mi | 14235809 ft | 2342.91 nm
   # Circle Area: 59148550160090 m2 | 59148550.16 km2
   # Lat,Lon: 43.58039,-108.28788
+  @northAmerica %Geocalc.Shape.Circle{
+    latitude: 43.58039,
+    longitude: -108.28788,
+    radius: 4_339_075
+  }
   defp isInNorthAmerica(latitude, longitude) do
-    northAmerica = %Geocalc.Shape.Circle{
-      latitude: 43.58039,
-      longitude: -108.28788,
-      radius: 4_339_075
-    }
-
-    isCoordinatesInArea?(latitude, longitude, northAmerica)
+    isCoordinatesInArea?(latitude, longitude, @northAmerica)
   end
 
   # Africa
   # Radius: 4288616 m | 4288.62 km | 2664.82 mi | 14070261 ft | 2315.67 nm
   # Circle Area: 57780874169219 m2 | 57780874.17 km2
   # Lat,Lon: -0.35156,9.14677
-
+  @africa %Geocalc.Shape.Circle{
+    latitude: -0.35156,
+    longitude: 9.14677,
+    radius: 4_288_616
+  }
   defp isInAfrica(latitude, longitude) do
-    africa = %Geocalc.Shape.Circle{
-      latitude: -0.35156,
-      longitude: 9.14677,
-      radius: 4_288_616
-    }
-
-    isCoordinatesInArea?(latitude, longitude, africa)
+    isCoordinatesInArea?(latitude, longitude, @africa)
   end
 
   # Asia
   # Radius: 5255297 m | 5255.30 km | 3265.49 mi | 17241790 ft | 2837.63 nm
   # Circle Area: 86764979261076 m2 | 86764979.26 km2
   # Lat,Lon: 34.30714,96.69073
+  @asia %Geocalc.Shape.Circle{
+    latitude: 34.30714,
+    longitude: 96.69073,
+    radius: 5_255_297
+  }
   defp isInAsia(latitude, longitude) do
-    asia = %Geocalc.Shape.Circle{
-      latitude: 34.30714,
-      longitude: 96.69073,
-      radius: 5_255_297
-    }
-
-    isCoordinatesInArea?(latitude, longitude, asia)
+    isCoordinatesInArea?(latitude, longitude, @asia)
   end
 
   # Australia
   # Radius: 3230549 m | 3230.55 km | 2007.37 mi | 10598913 ft | 1744.36 nm
   # Circle Area: 32787058546523 m2 | 32787058.55 km2
   # Lat,Lon: -25.89887,146.40949
+  @australia %Geocalc.Shape.Circle{
+    latitude: -25.89887,
+    longitude: 146.40949,
+    radius: 3_230_549
+  }
   defp isInAustralia(latitude, longitude) do
-    australia = %Geocalc.Shape.Circle{
-      latitude: -25.89887,
-      longitude: 146.40949,
-      radius: 3_230_549
-    }
-
-    isCoordinatesInArea?(latitude, longitude, australia)
+    isCoordinatesInArea?(latitude, longitude, @australia)
   end
 
   @doc ~S"""
@@ -101,39 +96,39 @@ defmodule Geo do
     ## Examples
 
       # Melbourne
-      iex> Geo.getContinentForCoordinates(-37.814479, 144.965794)
+      iex> Continents.getContinentForCoordinates(-37.814479, 144.965794)
       :australia
 
       # Paris
-      iex> Geo.getContinentForCoordinates(48.8588897, 2.320041)
+      iex> Continents.getContinentForCoordinates(48.8588897, 2.320041)
       :europe
 
       # Lisbonne
-      iex> Geo.getContinentForCoordinates(38.6979940, -9.1265504)
+      iex> Continents.getContinentForCoordinates(38.6979940, -9.1265504)
       :europe
 
       # Moscou
-      iex> Geo.getContinentForCoordinates(55.7504461, 37.6174943)
+      iex> Continents.getContinentForCoordinates(55.7504461, 37.6174943)
       :europe
 
       # Moscou
-      iex> Geo.getContinentForCoordinates(55.7504461, 37.6174943)
+      iex> Continents.getContinentForCoordinates(55.7504461, 37.6174943)
       :europe
 
       # Pekin
-      iex> Geo.getContinentForCoordinates(39.8919532, 116.4442401)
+      iex> Continents.getContinentForCoordinates(39.8919532, 116.4442401)
       :asia
 
       # Le Caire
-      iex> Geo.getContinentForCoordinates(30.0443879, 31.2357257)
+      iex> Continents.getContinentForCoordinates(30.0443879, 31.2357257)
       :africa
 
       # New York
-      iex> Geo.getContinentForCoordinates(40.7127281, -74.0060152)
+      iex> Continents.getContinentForCoordinates(40.7127281, -74.0060152)
       :northamerica
 
       # Other (pacific ocean)
-      iex> Geo.getContinentForCoordinates(42.7341014, -175.879978)
+      iex> Continents.getContinentForCoordinates(42.7341014, -175.879978)
       :other
 
   """

--- a/lib/jobs.ex
+++ b/lib/jobs.ex
@@ -1,7 +1,7 @@
 defmodule Jobs do
   @type job :: %{
           professionCategory: Professions.professionCategory(),
-          continent: Geo.continent()
+          continent: Continents.continent()
         }
   @type t :: [job]
 end
@@ -19,7 +19,7 @@ defmodule JobsService do
       Return the number of jobs by continents and categories
   """
   @spec getNumberOfJobsByContinentsAndCategories(Jobs.t()) :: %{
-          Geo.continent() => %{Professions.professionCategory() => integer()}
+          Continents.continent() => %{Professions.professionCategory() => integer()}
         }
   def getNumberOfJobsByContinentsAndCategories(jobs) do
     jobs
@@ -32,7 +32,7 @@ defmodule JobsService do
   @doc """
       Return all the continents
   """
-  @spec getContinents(Jobs.t()) :: [Geo.continent()]
+  @spec getContinents(Jobs.t()) :: [Continents.continent()]
   def getContinents(jobs) do
     jobs
     |> Enum.reduce(MapSet.new(), fn %{continent: c}, acc -> MapSet.put(acc, c) end)
@@ -61,7 +61,7 @@ defmodule JobsService do
   @doc """
       Total by continents
   """
-  @spec totalByContinents(Jobs.t()) :: %{Geo.continent() => integer()}
+  @spec totalByContinents(Jobs.t()) :: %{Continents.continent() => integer()}
   def totalByContinents(jobs) do
     getNumberOfJobsByContinentsAndCategories(jobs)
     |> Enum.reduce(%{}, fn {k, v}, acc ->

--- a/lib/main.ex
+++ b/lib/main.ex
@@ -5,17 +5,17 @@ defmodule Main.Router do
   plug(:dispatch)
 
   get "/" do
-    jobs = Jobs.getJobs(Professions.getProfessions())
+    jobs = JobsService.getJobs(ProfessionsService.getProfessions())
 
     body =
       EEx.eval_file("lib/router/template/table.html.eex",
-        categories: JobsInfo.getCategories(jobs),
-        totalByCategories: JobsInfo.totalByCategories(jobs),
-        continents: JobsInfo.getContinents(jobs),
-        totalByContinents: JobsInfo.totalByContinents(jobs),
-        total: JobsInfo.totalOfJobs(jobs),
+        categories: JobsService.getCategories(jobs),
+        totalByCategories: JobsService.totalByCategories(jobs),
+        continents: JobsService.getContinents(jobs),
+        totalByContinents: JobsService.totalByContinents(jobs),
+        total: JobsService.totalOfJobs(jobs),
         numberOfJobsByContinentsAndCategories:
-          JobsInfo.getNumberOfJobsByContinentsAndCategories(jobs)
+          JobsService.getNumberOfJobsByContinentsAndCategories(jobs)
       )
 
     send_resp(conn, 200, body)
@@ -37,7 +37,7 @@ defmodule Main.Application do
 
     opts = [strategy: :one_for_one, name: Main.Supervisor]
 
-    Logger.info("Starting application...")
+    Logger.info("Starting application (http://localhost:8080)...")
 
     Supervisor.start_link(children, opts)
   end

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -36,8 +36,8 @@ defmodule CSVParser do
   @spec transformRowIntoProfession(map()) :: Professions.profession()
   defp transformRowIntoProfession(row) do
     case row do
-      %{"id" => id, "name" => name, "category_name" => category} ->
-        %{id: String.to_integer(id), name: name, category: category}
+      %{"id" => id, "category_name" => category} ->
+        {String.to_integer(id), category}
     end
   end
 
@@ -46,8 +46,6 @@ defmodule CSVParser do
     case row do
       %{
         "profession_id" => id,
-        "contract_type" => contractType,
-        "name" => name,
         "office_latitude" => latitudeStr,
         "office_longitude" => longitudeStr
       } ->
@@ -56,13 +54,8 @@ defmodule CSVParser do
         professionId = String.to_integer(id)
 
         %{
-          professionId: professionId,
           professionCategory:
-            ProfessionsInfo.getProfessionCategoryForProfessionId(professions, professionId),
-          contractType: contractType,
-          name: name,
-          latitude: lat,
-          longitude: lon,
+            ProfessionsService.getProfessionCategoryForProfessionId(professions, professionId),
           continent: Geo.getContinentForCoordinates(lat, lon)
         }
     end
@@ -73,18 +66,15 @@ defmodule CSVParser do
     Parse the CSV file containing the professions and put the result in a profession list
 
     ## Examples
-      iex> CSVParser.parseProfessions()
-      iex> |> Enum.take(2)
-      [%{
-        id: 17,
-        name: "Devops / Infrastructure",
-        category: "Tech"
-      },
-      %{
-        id: 24,
-        name: "Compta / Contrôle de Gestion",
-        category: "Admin"
-      }]
+      iex> Map.get(CSVParser.parseProfessions(), 17)
+      "Tech"
+
+      iex> Map.get(CSVParser.parseProfessions(), 25)
+      "Admin"
+
+      iex> Map.get(CSVParser.parseProfessions(), 4)
+      "Marketing / Comm'"
+
   """
   @spec parseProfessions() :: Professions.t()
   def parseProfessions() do
@@ -92,6 +82,8 @@ defmodule CSVParser do
       "resources/technical-test-professions.csv",
       &transformRowIntoProfession/1
     )
+    # Here Map.new creates a Map from Tuples
+    |> Map.new()
   end
 
   @doc ~S"""

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -56,7 +56,7 @@ defmodule CSVParser do
         %{
           professionCategory:
             ProfessionsService.getProfessionCategoryForProfessionId(professions, professionId),
-          continent: Geo.getContinentForCoordinates(lat, lon)
+          continent: Continents.getContinentForCoordinates(lat, lon)
         }
     end
   end

--- a/lib/professions.ex
+++ b/lib/professions.ex
@@ -1,34 +1,25 @@
 defmodule Professions do
   @type professionId :: integer()
   @type professionCategory :: String.t()
-  @type profession :: %{id: professionId(), name: String.t(), category: professionCategory()}
-  @type t :: [profession]
+  @type profession :: {professionId(), professionCategory()}
+  @type t :: %{professionId() => professionCategory()}
+end
 
-  @spec getProfessions() :: t()
+defmodule ProfessionsService do
+  @doc """
+    Return all the professions
+  """
+  @spec getProfessions() :: Professions.t()
   def getProfessions() do
     CSVParser.parseProfessions()
   end
-end
 
-defmodule ProfessionsInfo do
-  defp professionsByProfessionId(professions) do
-    professions |> Map.new(fn p -> {p.id, p} end)
-  end
-
-  @doc ~S"""
+  @doc """
       Return the profession category for a profession id
-
-      ## Examples
-
-        iex> Professions.getProfessionCategoryForProfessionId(18)
-        "Tech"
-
-        iex> Professions.getProfessionCategoryForProfessionId(31)
-        "Retail"
   """
   @spec getProfessionCategoryForProfessionId(Professions.t(), Professions.professionId()) ::
           Professions.professionCategory()
   def getProfessionCategoryForProfessionId(professions, professionId) do
-    professionsByProfessionId(professions)[professionId].category
+    professions[professionId]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule TestElixir.MixProject do
   defp aliases do
     [
       c: "compile",
-      test: ["test --cover"],
+      test: ["test --cover --trace"],
       run: ["run --no-halt"]
     ]
   end

--- a/test/continents_test.exs
+++ b/test/continents_test.exs
@@ -1,0 +1,4 @@
+defmodule ContinentsTest do
+  use ExUnit.Case, async: true
+  doctest Continents
+end

--- a/test/geo_test.exs
+++ b/test/geo_test.exs
@@ -1,4 +1,0 @@
-defmodule GeoTest do
-  use ExUnit.Case, async: true
-  doctest Geo
-end

--- a/test/jobs_test.exs
+++ b/test/jobs_test.exs
@@ -1,32 +1,78 @@
 defmodule JobsTest do
   use ExUnit.Case, async: true
-  doctest Jobs
 
-  @professions Professions.getProfessions()
-  @jobs Jobs.getJobs(@professions)
+  @professions ProfessionsService.getProfessions()
+  @jobs JobsService.getJobs(@professions)
+
+  test "Return all the jobs" do
+    assert @jobs |> Enum.take(2) === [
+             %{
+               continent: :europe,
+               professionCategory: "Marketing / Comm'"
+             },
+             %{
+               continent: :europe,
+               professionCategory: "Business"
+             }
+           ]
+  end
 
   test "Return the number of jobs by continents and categories" do
-    assert JobsInfo.getNumberOfJobsByContinentsAndCategories(@jobs)
-    |> Map.get(:africa) === %{"Admin" => 1, "Business" => 1, "Marketing / Comm'" => 1, "Retail" => 8, "Tech" => 5}
+    assert JobsService.getNumberOfJobsByContinentsAndCategories(@jobs)
+           |> Map.get(:africa) === %{
+             "Admin" => 1,
+             "Business" => 1,
+             "Marketing / Comm'" => 1,
+             "Retail" => 8,
+             "Tech" => 5
+           }
   end
 
   test "Return all the continents" do
-    assert JobsInfo.getContinents(@jobs) === [:africa, :asia, :australia, :europe, :northamerica]
+    assert JobsService.getContinents(@jobs) === [
+             :africa,
+             :asia,
+             :australia,
+             :europe,
+             :northamerica
+           ]
   end
 
   test "Return all the categories" do
-    assert JobsInfo.getCategories(@jobs) === ["Admin", "Business", "Conseil", "Créa", "Marketing / Comm'", "Retail", "Tech"]
+    assert JobsService.getCategories(@jobs) === [
+             "Admin",
+             "Business",
+             "Conseil",
+             "Créa",
+             "Marketing / Comm'",
+             "Retail",
+             "Tech"
+           ]
   end
 
   test "Total by categories" do
-    assert JobsInfo.totalByCategories(@jobs) === %{"Admin" => 407, "Business" => 1436, "Conseil" => 175, "Créa" => 212, "Marketing / Comm'" => 776, "Retail" => 528, "Tech" => 1431}
+    assert JobsService.totalByCategories(@jobs) === %{
+             "Admin" => 407,
+             "Business" => 1436,
+             "Conseil" => 175,
+             "Créa" => 212,
+             "Marketing / Comm'" => 776,
+             "Retail" => 528,
+             "Tech" => 1431
+           }
   end
 
   test "Total by continents" do
-    assert JobsInfo.totalByContinents(@jobs) === %{africa: 16, asia: 52, australia: 1, europe: 4737, northamerica: 159}
+    assert JobsService.totalByContinents(@jobs) === %{
+             africa: 16,
+             asia: 52,
+             australia: 1,
+             europe: 4737,
+             northamerica: 159
+           }
   end
 
   test "Total of jobs" do
-    assert JobsInfo.totalOfJobs(@jobs) === 4965
+    assert JobsService.totalOfJobs(@jobs) === 4965
   end
 end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -5,23 +5,15 @@ defmodule CSVParserTest do
   @professions CSVParser.parseProfessions()
 
   test "Parse the CSV file containing the jobs and put the result in a job list" do
-    assert CSVParser.parseJobs(@professions) |> Enum.take(2) === [%{
-      contractType: "INTERNSHIP",
-      latitude: 48.1392154,
-      longitude: 11.5781413,
-      name: "[Louis Vuitton Germany] Praktikant (m/w) im Bereich Digital Retail (E-Commerce)",
-      professionId: 7,
-      continent: :europe,
-      professionCategory: "Marketing / Comm'"
-    },
-    %{
-      contractType: "INTERNSHIP",
-      latitude: 48.885247,
-      longitude: 2.3566441,
-      name: "Bras droit de la fondatrice",
-      professionId: 5,
-      continent: :europe,
-      professionCategory: "Business"
-    }]
+    assert CSVParser.parseJobs(@professions) |> Enum.take(2) === [
+             %{
+               continent: :europe,
+               professionCategory: "Marketing / Comm'"
+             },
+             %{
+               continent: :europe,
+               professionCategory: "Business"
+             }
+           ]
   end
 end

--- a/test/professions_test.exs
+++ b/test/professions_test.exs
@@ -1,4 +1,13 @@
 defmodule ProfessionsTest do
   use ExUnit.Case, async: true
-  doctest Professions
+  doctest ProfessionsService
+
+  @professions ProfessionsService.getProfessions()
+
+  test "Return the profession category from a profession id" do
+    assert ProfessionsService.getProfessionCategoryForProfessionId(@professions, 18) === "Tech"
+
+    assert ProfessionsService.getProfessionCategoryForProfessionId(@professions, 31) ===
+             "Retail"
+  end
 end


### PR DESCRIPTION
- Cleaning useless data from Jobs and Professions models
- Refactoring data models for the Professions. Instead of using a `List`, I use a `Map`. This is easier to retrieve the Profession category
- Refactoring methods for the Jobs. In the previous version, the job list was traversed more times. 
- Renaming `Geo` module into `Continents` and clean it since the `Geocalc.shape` are instantiated a lot of times